### PR TITLE
Update FROM for new naming convention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM onmodulus/image-run-base:0.0.1
+FROM onmodulus/run-base
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Fix issue where bootstrap.sh would not complete

Update for new FROM image name convention

Revert "Fix issue where bootstrap.sh would not complete"

This reverts commit a88cea7ed5f3c2078129ea5e60b4170e770dd618.
